### PR TITLE
Button share

### DIFF
--- a/src/components/ButtonShare.tsx
+++ b/src/components/ButtonShare.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Button } from "./ui/button";
+
+export default function ButtonShare({ evento }: { evento: any }) {
+  const [url, setUrl] = useState("");
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setUrl(window.location.href); // pega a URL atual do evento
+    }
+  }, []);
+
+  const handleShare = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: evento.titulo,
+          text: `Confira este evento: ${evento.titulo} em ${evento.local}`,
+          url,
+        });
+      } catch (error) {
+        console.error("Erro ao compartilhar:", error);
+      }
+    } else {
+      alert("Compartilhamento nativo não suportado neste dispositivo 😕");
+    }
+  };
+
+  return (
+    <Button
+      onClick={handleShare}
+      className="p-2.5 bg-slate-900 text-white text-base rounded-lg capitalize hover:bg-orange-600 transition-colors duration-300"
+    >
+      Compartilhar evento
+    </Button>
+  );
+}

--- a/src/components/ButtonShare.tsx
+++ b/src/components/ButtonShare.tsx
@@ -2,7 +2,12 @@
 import { useEffect, useState } from "react";
 import { Button } from "./ui/button";
 
-export default function ButtonShare({ evento }: { evento: any }) {
+interface Evento {
+  titulo: string;
+  local: string;
+}
+
+export default function ButtonShare({ evento }: { evento: Evento }) {
   const [url, setUrl] = useState("");
 
   useEffect(() => {

--- a/src/components/proximosEventos.tsx
+++ b/src/components/proximosEventos.tsx
@@ -30,11 +30,18 @@ export default function ProximosEventos() {
   const updateItemsPerPage = () => {
     const largura = window.innerWidth;
 
-    if (largura <= 425) setEventoPorPagina(1);
-    else if (largura <= 768) setEventoPorPagina(2);
-    else if (largura <= 1024) setEventoPorPagina(3);
-    else if (largura <= 1200) setEventoPorPagina(4);
-    else setEventoPorPagina(4);
+    // Dispositivos móveis com largura próxima de 428px (iPhone 12 Pro Max, etc.)
+    if (largura <= 430) {
+      setEventoPorPagina(1);
+    } else if (largura <= 768) {
+      setEventoPorPagina(2);
+    } else if (largura <= 1024) {
+      setEventoPorPagina(3);
+    } else if (largura <= 1200) {
+      setEventoPorPagina(4);
+    } else {
+      setEventoPorPagina(4);
+    }
   };
 
   useEffect(() => {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -22,7 +22,7 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        default: "h-11 px-4 py-2 has-[>svg]:px-3",
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
@@ -33,7 +33,7 @@ const buttonVariants = cva(
       size: "default",
     },
   }
-)
+);
 
 function Button({
   className,
@@ -43,9 +43,9 @@ function Button({
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot : "button"
+  const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
@@ -53,7 +53,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/pages/eventos/[id]/index.tsx
+++ b/src/pages/eventos/[id]/index.tsx
@@ -54,8 +54,8 @@ export default function EventoPage() {
           </div>
 
           <div className="w-full h-auto flex flex-col mt-5">
-            <div className="w-full h-auto flex flex-row justify-between items-start gap-3">
-              <div className="flex flex-col">
+            <div className="w-full h-auto flex sm:flex-row flex-col justify-between items-start gap-3">
+              <div className="flex flex-col p-1.5">
                 <h1 className="text-base md:text-lg lg:text-2xl font-bold capitalize">
                   {evento.titulo}
                 </h1>
@@ -91,10 +91,10 @@ export default function EventoPage() {
                 </p>
 
                 {/* Botões de ação */}
-                <div className="w-full flex flex-row gap-3">
+                <div className="w-full flex sm:flex-row flex-col gap-3">
                   {/* Botão de compra */}
                   <Link
-                    className="p-2.5 bg-slate-900 text-white text-base rounded-lg capitalize hover:bg-orange-600 transition-colors duration-300"
+                    className="p-2.5 bg-slate-900 text-white text-center text-base rounded-lg capitalize hover:bg-orange-600 transition-colors duration-300"
                     href={evento.link_compra || "#"}
                     target="_blank"
                   >

--- a/src/pages/eventos/[id]/index.tsx
+++ b/src/pages/eventos/[id]/index.tsx
@@ -9,6 +9,7 @@ import { Evento } from "@/types";
 import Link from "next/link";
 import imageTemplate from "@/assets/imgTemplate.png";
 import { formatEventDate } from "@/lib/utils";
+import ButtonShare from "@/components/ButtonShare";
 
 export default function EventoPage() {
   const [evento, setEvento] = useState<Evento | null>(null);
@@ -82,16 +83,27 @@ export default function EventoPage() {
             <div className="w-full h-auto flex flex-col">
               <div className="w-full min-h-15 flex flex-col justify-start items-start">
                 <p className="text-lg text-orange-500 font-bold my-5">
-                  {evento.valor === "0.00" || evento.valor === 0 ? "Grátis" : evento.valor === "1.00" || evento.valor === 1 ? "Em breve" : `R$${evento.valor}`}
+                  {evento.valor === "0.00" || evento.valor === 0
+                    ? "Grátis"
+                    : evento.valor === "1.00" || evento.valor === 1
+                    ? "Em breve"
+                    : `R$${evento.valor}`}
                 </p>
 
-                <Link
-                  className="p-2.5 bg-slate-900 text-white text-base rounded-lg capitalize"
-                  href={evento.link_compra || "#"}
-                  target="_blank"
-                >
-                  Comprar ingresso
-                </Link>
+                {/* Botões de ação */}
+                <div className="w-full flex flex-row gap-3">
+                  {/* Botão de compra */}
+                  <Link
+                    className="p-2.5 bg-slate-900 text-white text-base rounded-lg capitalize hover:bg-orange-600 transition-colors duration-300"
+                    href={evento.link_compra || "#"}
+                    target="_blank"
+                  >
+                    Comprar ingresso
+                  </Link>
+
+                  {/* Botão de compartilhamento */}
+                  <ButtonShare evento={evento} />
+                </div>
               </div>
 
               <div className="w-full mt-5">


### PR DESCRIPTION
This pull request introduces a new "Share Event" button to the event details page, improves the responsiveness of event listings for certain mobile devices, and makes small style and code consistency updates to the button component. The most important changes are grouped below:

**New Feature: Event Sharing**

* Added a new `ButtonShare` component that uses the Web Share API to allow users to share event details directly from the event page. This button is integrated alongside the "Buy Ticket" button on the event details page. (`src/components/ButtonShare.tsx`, `src/pages/eventos/[id]/index.tsx`) ([src/components/ButtonShare.tsxR1-R43](diffhunk://#diff-4a39c7fe78a706fd091e5a31a52d2b628129b9a76a2548a0e730027c92669d2cR1-R43), [src/pages/eventos/[id]/index.tsxR12](diffhunk://#diff-09e359dc5c03ef63ab8e603aef995e1cf2763522479feb97c209e1bcbe5147feR12), [src/pages/eventos/[id]/index.tsxL85-R106](diffhunk://#diff-09e359dc5c03ef63ab8e603aef995e1cf2763522479feb97c209e1bcbe5147feL85-R106))

**Responsiveness Improvements**

* Adjusted the logic in `ProximosEventos` to better handle mobile devices with widths near 428px, ensuring a smoother experience on devices like the iPhone 12 Pro Max. (`src/components/proximosEventos.tsx`)

**Button Component Updates**

* Increased the default button height for improved visual consistency and made minor formatting and code style improvements in the `Button` component. (`src/components/ui/button.tsx`) [[1]](diffhunk://#diff-c29ec4c06502c45a9ee8740156618a5823f7cadbcd01a339304a66537c0dc30dL1-R5) [[2]](diffhunk://#diff-c29ec4c06502c45a9ee8740156618a5823f7cadbcd01a339304a66537c0dc30dL25-R25) [[3]](diffhunk://#diff-c29ec4c06502c45a9ee8740156618a5823f7cadbcd01a339304a66537c0dc30dL36-R36) [[4]](diffhunk://#diff-c29ec4c06502c45a9ee8740156618a5823f7cadbcd01a339304a66537c0dc30dL46-R59)

**UI Layout Adjustments**

* Improved the layout and spacing of elements on the event details page, including better padding and responsive flex layouts for action buttons. (`src/pages/eventos/[id]/index.tsx`) ([src/pages/eventos/[id]/index.tsxL56-R58](diffhunk://#diff-09e359dc5c03ef63ab8e603aef995e1cf2763522479feb97c209e1bcbe5147feL56-R58), [src/pages/eventos/[id]/index.tsxL85-R106](diffhunk://#diff-09e359dc5c03ef63ab8e603aef995e1cf2763522479feb97c209e1bcbe5147feL85-R106))